### PR TITLE
添加customJS可选配置项，完善脚本插入逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ postchat:
     defaultChatQuestions: ["你好","你是谁"] # 默认聊天问题，仅在Magic模式下有效
     defaultSearchQuestions: ["视频压缩","设计"] # 默认搜索问题，仅在Magic模式下有效
     addButton: true # 是否显示按钮
+  customJS: "" # 可选，自定义JS地址，如果不配置则为官方CDN(如下三种情况)
+  # # PostChat and Summary: https://ai.tianli0.top/static/public/postChatUser_summary.min.js
+  # # Only PostChat: https://ai.tianli0.top/static/public/postChatUser.min.js
+  # # Only Summary: https://ai.tianli0.top/static/public/tianli_gpt.min.js
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ hexo.extend.filter.register('after_render:html', function (data) {
   // 读取配置项
   const config = hexo.config.postchat || {};
 
-    // 新增 customJS 配置项
-    const customJS = config.customJS || "";
+  // 新增 customJS 配置项
+  const customJS = config.customJS || "";
 
   const {
     account = {},
@@ -64,18 +64,10 @@ hexo.extend.filter.register('after_render:html', function (data) {
     defaultSearchQuestions = ["视频压缩", "设计"]
   } = chat;
 
-  // 插入脚本代码
-  const script = `
-    <link rel="stylesheet" href="${summaryStyle}">
-    <script>
-        let tianliGPT_key = '${key}';
-        let tianliGPT_postSelector = '${postSelector}';
-        let tianliGPT_Title = '${title}';
-        let tianliGPT_postURL = '${postURL}';
-        let tianliGPT_blacklist = '${blacklist}';
-        let tianliGPT_wordLimit = '${wordLimit}';
-        let tianliGPT_typingAnimate = ${typingAnimate};
-        let tianliGPT_theme = '${summaryTheme}';
+    // 动态生成postChat配置部分
+    let postChatConfigScript = '';
+    if (enableAI) {
+      postChatConfigScript = `
         var postChatConfig = {
           backgroundColor: "${backgroundColor}",
           bottom: "${bottom}",
@@ -95,7 +87,21 @@ hexo.extend.filter.register('after_render:html', function (data) {
           userMode: "${userMode}",
           defaultChatQuestions: ${JSON.stringify(defaultChatQuestions)},
           defaultSearchQuestions: ${JSON.stringify(defaultSearchQuestions)}
-        };
+        };`;
+    }
+
+    const script = `
+    <link rel="stylesheet" href="${summaryStyle}">
+    <script>
+        let tianliGPT_key = '${key}';
+        let tianliGPT_postSelector = '${postSelector}';
+        let tianliGPT_Title = '${title}';
+        let tianliGPT_postURL = '${postURL}';
+        let tianliGPT_blacklist = '${blacklist}';
+        let tianliGPT_wordLimit = '${wordLimit}';
+        let tianliGPT_typingAnimate = ${typingAnimate};
+        let tianliGPT_theme = '${summaryTheme}';
+        ${postChatConfigScript}
     </script>
     <script data-postChat_key="${key}" src="%s"></script>
   `;

--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ hexo.extend.filter.register('after_render:html', function (data) {
   // 读取配置项
   const config = hexo.config.postchat || {};
 
+    // 新增 customJS 配置项
+    const customJS = config.customJS || "";
+
   const {
     account = {},
     summary = {},
@@ -97,16 +100,20 @@ hexo.extend.filter.register('after_render:html', function (data) {
     <script data-postChat_key="${key}" src="%s"></script>
   `;
 
-  // 确定插入的JS文件地址
-  let scriptSrc;
-  if (enableAI && enableSummary) {
-    scriptSrc = "https://ai.tianli0.top/static/public/postChatUser_summary.min.js";
-  } else if (enableAI) {
-    scriptSrc = "https://ai.tianli0.top/static/public/postChatUser.min.js";
-  } else if (enableSummary) {
-    scriptSrc = "https://ai.tianli0.top/static/public/tianli_gpt.min.js";
-  } else {
-    scriptSrc = "";
+  // 优先使用自定义 JS 地址
+  let scriptSrc = customJS;
+  
+  if (!scriptSrc) {
+    // 默认逻辑保持不变
+    if (enableAI && enableSummary) {
+      scriptSrc = "https://ai.tianli0.top/static/public/postChatUser_summary.min.js";
+    } else if (enableAI) {
+      scriptSrc = "https://ai.tianli0.top/static/public/postChatUser.min.js";
+    } else if (enableSummary) {
+      scriptSrc = "https://ai.tianli0.top/static/public/tianli_gpt.min.js";
+    } else {
+      scriptSrc = "";
+    }
   }
 
   if (scriptSrc) {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,23 @@
 {
   "name": "hexo-plugin-postchat",
-  "version": "2.0.0",
-  "description": "站点AI增强工具，实现文章摘要与知识库对话",
+  "version": "2.1.0",
+  "description": "🤖站点AI增强工具，实现文章摘要与知识库对话",
   "main": "index.js",
   "author": "张洪Heo",
   "license": "仅用于PostChat服务",
   "dependencies": {
     "cheerio": "^1.0.0-rc.10"
-  }
+  },
+  "keywords": [
+    "hexo",
+    "plugin",
+    "tianligpt",
+    "postchat",
+    "ai"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zhheo/hexo-plugin-postchat.git"
+  },
+  "homepage": "https://postchat.zhheo.com/plugin/hexo.html"
 }

--- a/update.md
+++ b/update.md
@@ -6,6 +6,11 @@ npm login
 
 npm publish
 
+## 2.1.0
+
+新增 customJS 配置项支持自定义脚本地址
+优化配置生成逻辑，改进 enableAI 为 false 时的脚本插入
+
 ## 2.0.0
 PostChat支持全新的Magic模式（将默认启用）
 


### PR DESCRIPTION
1. 添加`customJS`可选配置项，用于自定义CDN
2. 优化脚本插入逻辑，当`enableAI`为`false`时仅插入`tianligpt`相关配置，减少代码量
3. 完善说明文档，更新文档，完善`package.json`包信息